### PR TITLE
SafariVCへの遷移の実装、tableViewCellに他の情報を追加

### DIFF
--- a/CtaReactiveMaster.xcodeproj/project.pbxproj
+++ b/CtaReactiveMaster.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		6A86676C2598D35E00FE8031 /* APIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6A86676B2598D35E00FE8031 /* APIKey.plist */; };
 		6A92D40B25728F3200256220 /* NewsDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A92D40A25728F3200256220 /* NewsDataModel.swift */; };
 		6AA0A2522579181900A99393 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA0A2512579181900A99393 /* APIClient.swift */; };
+		6AAABEB9259B7D5A008F9825 /* UIImageView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAABEB8259B7D5A008F9825 /* UIImageView+Extension.swift */; };
 		6ACDDDC3256BE65F004E12E3 /* ArticleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACDDDC1256BE65F004E12E3 /* ArticleTableViewCell.swift */; };
 		6ACDDDC4256BE65F004E12E3 /* ArticleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6ACDDDC2256BE65F004E12E3 /* ArticleTableViewCell.xib */; };
 		82796DEF2569247500443E2F /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82796DED2569247500443E2F /* HomeViewController.swift */; };
@@ -53,6 +54,7 @@
 		6A86676B2598D35E00FE8031 /* APIKey.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = APIKey.plist; sourceTree = "<group>"; };
 		6A92D40A25728F3200256220 /* NewsDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsDataModel.swift; sourceTree = "<group>"; };
 		6AA0A2512579181900A99393 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		6AAABEB8259B7D5A008F9825 /* UIImageView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extension.swift"; sourceTree = "<group>"; };
 		6ACDDDC1256BE65F004E12E3 /* ArticleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleTableViewCell.swift; sourceTree = "<group>"; };
 		6ACDDDC2256BE65F004E12E3 /* ArticleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ArticleTableViewCell.xib; sourceTree = "<group>"; };
 		705E3A12E8A77B5A88182FE7 /* Pods_CtaReactiveMasterTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CtaReactiveMasterTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -208,6 +210,7 @@
 			children = (
 				82796DE6256923F700443E2F /* Resources */,
 				82796DE5256923ED00443E2F /* Sources */,
+				6AAABEB8259B7D5A008F9825 /* UIImageView+Extension.swift */,
 			);
 			path = CtaReactiveMaster;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 			files = (
 				6A5F2E8A257D13C200D5DB4A /* NewsArticleRepository.swift in Sources */,
 				6A6DC2F6259636E500191F29 /* Language.swift in Sources */,
+				6AAABEB9259B7D5A008F9825 /* UIImageView+Extension.swift in Sources */,
 				6A6DC2F2259636A900191F29 /* Country.swift in Sources */,
 				6A92D40B25728F3200256220 /* NewsDataModel.swift in Sources */,
 				6ACDDDC3256BE65F004E12E3 /* ArticleTableViewCell.swift in Sources */,

--- a/CtaReactiveMaster/Sources/Home/Cell/ArticleTableViewCell.swift
+++ b/CtaReactiveMaster/Sources/Home/Cell/ArticleTableViewCell.swift
@@ -8,28 +8,28 @@
 import UIKit
 
 final class ArticleTableViewCell: UITableViewCell {
-    @IBOutlet weak var titleLabel: UILabel! {
+    @IBOutlet private weak var titleLabel: UILabel! {
         didSet {
             titleLabel.font = .systemFont(ofSize: 17, weight: .bold)
             titleLabel.numberOfLines = 2
         }
     }
     
-    @IBOutlet weak var articleImageView: UIImageView! {
+    @IBOutlet private weak var articleImageView: UIImageView! {
         didSet {
             articleImageView.contentMode = .scaleAspectFill
             articleImageView.layer.cornerRadius = 5
         }
     }
     
-    @IBOutlet weak var descriptionLabel: UILabel! {
+    @IBOutlet private weak var descriptionLabel: UILabel! {
         didSet {
             descriptionLabel.font = .systemFont(ofSize: 14)
             descriptionLabel.numberOfLines = 3
         }
     }
     
-    @IBOutlet weak var authorLabel: UILabel! {
+    @IBOutlet private weak var authorLabel: UILabel! {
         didSet {
             authorLabel.font = .systemFont(ofSize: 10)
             authorLabel.textAlignment = .right
@@ -37,7 +37,7 @@ final class ArticleTableViewCell: UITableViewCell {
         }
     }
     
-    func setUpInformation(article: Article) {
+    func configure(article: Article) {
         articleImageView.loadImage(from: article.urlToImage)
         titleLabel.text = article.title
         descriptionLabel.text = article.description

--- a/CtaReactiveMaster/Sources/Home/Cell/ArticleTableViewCell.swift
+++ b/CtaReactiveMaster/Sources/Home/Cell/ArticleTableViewCell.swift
@@ -8,5 +8,39 @@
 import UIKit
 
 final class ArticleTableViewCell: UITableViewCell {
-    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var titleLabel: UILabel! {
+        didSet {
+            titleLabel.font = .systemFont(ofSize: 17, weight: .bold)
+            titleLabel.numberOfLines = 2
+        }
+    }
+    
+    @IBOutlet weak var articleImageView: UIImageView! {
+        didSet {
+            articleImageView.contentMode = .scaleAspectFill
+            articleImageView.layer.cornerRadius = 5
+        }
+    }
+    
+    @IBOutlet weak var descriptionLabel: UILabel! {
+        didSet {
+            descriptionLabel.font = .systemFont(ofSize: 14)
+            descriptionLabel.numberOfLines = 3
+        }
+    }
+    
+    @IBOutlet weak var authorLabel: UILabel! {
+        didSet {
+            authorLabel.font = .systemFont(ofSize: 10)
+            authorLabel.textAlignment = .right
+            authorLabel.textColor = .gray
+        }
+    }
+    
+    func setUpInformation(article: Article) {
+        articleImageView.loadImage(from: article.urlToImage)
+        titleLabel.text = article.title
+        descriptionLabel.text = article.description
+        authorLabel.text = article.author
+    }
 }

--- a/CtaReactiveMaster/Sources/Home/Cell/ArticleTableViewCell.xib
+++ b/CtaReactiveMaster/Sources/Home/Cell/ArticleTableViewCell.xib
@@ -1,37 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ArticleTableViewCell" customModule="CtaReactiveMaster" customModuleProvider="target"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="85" id="KGk-i7-Jjw" customClass="ArticleTableViewCell" customModule="CtaReactiveMaster" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="85"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="482" id="KGk-i7-Jjw" customClass="ArticleTableViewCell" customModule="CtaReactiveMaster" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="479" height="482"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="85"/>
+                <rect key="frame" x="0.0" y="0.0" width="479" height="482"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xf9-3H-SoL">
-                        <rect key="frame" x="23" y="20" width="274" height="45"/>
+                        <rect key="frame" x="20" y="10" width="439" height="54"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sZZ-Lg-m4x">
+                        <rect key="frame" x="20" y="81" width="439" height="250"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="439" id="2Td-9O-J9R"/>
+                            <constraint firstAttribute="height" constant="250" id="dkH-yq-nRN"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6dn-Yo-Ckg">
+                        <rect key="frame" x="20" y="339" width="439" height="75"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="75" id="Ynz-wZ-gca"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SHD-FT-LTX">
+                        <rect key="frame" x="264" y="422" width="176" height="37"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="Xf9-3H-SoL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="23" id="GuQ-5H-j8m"/>
-                    <constraint firstAttribute="trailing" secondItem="Xf9-3H-SoL" secondAttribute="trailing" constant="23" id="KUr-br-ZdV"/>
-                    <constraint firstAttribute="bottom" secondItem="Xf9-3H-SoL" secondAttribute="bottom" constant="20" id="M9y-be-jhn"/>
-                    <constraint firstAttribute="trailing" secondItem="Xf9-3H-SoL" secondAttribute="trailing" constant="23" id="Pq7-lm-j2N"/>
-                    <constraint firstItem="Xf9-3H-SoL" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="V5N-QQ-KlL"/>
-                    <constraint firstItem="Xf9-3H-SoL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="23" id="eUw-DK-RIs"/>
-                    <constraint firstItem="Xf9-3H-SoL" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="enO-CP-k5s"/>
+                    <constraint firstAttribute="trailing" secondItem="sZZ-Lg-m4x" secondAttribute="trailing" constant="20" symbolic="YES" id="0os-E3-trW"/>
+                    <constraint firstItem="6dn-Yo-Ckg" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" symbolic="YES" id="3Jh-eC-dbx"/>
+                    <constraint firstItem="Xf9-3H-SoL" firstAttribute="height" secondItem="H2p-sc-9uM" secondAttribute="height" multiplier="0.112033" id="8rc-3f-pn6"/>
+                    <constraint firstItem="SHD-FT-LTX" firstAttribute="width" relation="greaterThanOrEqual" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.263048" constant="50" id="8yV-Ha-xMx"/>
+                    <constraint firstItem="SHD-FT-LTX" firstAttribute="top" secondItem="6dn-Yo-Ckg" secondAttribute="bottom" constant="8" symbolic="YES" id="Dpk-xv-0cT"/>
+                    <constraint firstAttribute="trailing" secondItem="Xf9-3H-SoL" secondAttribute="trailing" constant="20" id="NN5-Ef-1CJ"/>
+                    <constraint firstItem="6dn-Yo-Ckg" firstAttribute="top" secondItem="sZZ-Lg-m4x" secondAttribute="bottom" constant="8" symbolic="YES" id="NQo-0X-cn7"/>
+                    <constraint firstItem="Xf9-3H-SoL" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="RNG-Bl-NID"/>
+                    <constraint firstItem="sZZ-Lg-m4x" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" symbolic="YES" id="aPe-iF-ITh"/>
+                    <constraint firstAttribute="trailing" secondItem="SHD-FT-LTX" secondAttribute="trailing" constant="39" id="dBe-ip-cRW"/>
+                    <constraint firstItem="sZZ-Lg-m4x" firstAttribute="top" secondItem="Xf9-3H-SoL" secondAttribute="bottom" constant="17" id="j87-hn-ncO"/>
+                    <constraint firstAttribute="bottom" secondItem="SHD-FT-LTX" secondAttribute="bottom" constant="23" id="kpU-Zf-NOh"/>
+                    <constraint firstAttribute="trailing" secondItem="6dn-Yo-Ckg" secondAttribute="trailing" constant="20" symbolic="YES" id="t6E-mU-mZ3"/>
+                    <constraint firstItem="Xf9-3H-SoL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" symbolic="YES" id="yiz-aD-6tC"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -39,9 +68,12 @@
                 <bool key="isElement" value="YES"/>
             </accessibility>
             <connections>
+                <outlet property="articleImageView" destination="sZZ-Lg-m4x" id="rVA-cx-r9p"/>
+                <outlet property="authorLabel" destination="SHD-FT-LTX" id="Z9z-Vz-z3m"/>
+                <outlet property="descriptionLabel" destination="6dn-Yo-Ckg" id="Pxh-7Q-0Rd"/>
                 <outlet property="titleLabel" destination="Xf9-3H-SoL" id="XqD-gy-Dna"/>
             </connections>
-            <point key="canvasLocation" x="140.57971014492756" y="138.28125"/>
+            <point key="canvasLocation" x="29.710144927536234" y="229.6875"/>
         </tableViewCell>
     </objects>
 </document>

--- a/CtaReactiveMaster/Sources/Home/HomeViewController.swift
+++ b/CtaReactiveMaster/Sources/Home/HomeViewController.swift
@@ -72,7 +72,7 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ArticleTableViewCell", for: indexPath) as! ArticleTableViewCell
-        cell.setUpInformation(article: articles[indexPath.row])
+        cell.configure(article: articles[indexPath.row])
         return cell
     }
     

--- a/CtaReactiveMaster/Sources/Home/HomeViewController.swift
+++ b/CtaReactiveMaster/Sources/Home/HomeViewController.swift
@@ -72,7 +72,7 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ArticleTableViewCell", for: indexPath) as! ArticleTableViewCell
-        cell.titleLabel.text = articles[indexPath.row].title
+        cell.setUpInformation(article: articles[indexPath.row])
         return cell
     }
     

--- a/CtaReactiveMaster/Sources/Home/HomeViewController.swift
+++ b/CtaReactiveMaster/Sources/Home/HomeViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import SafariServices
 
 final class HomeViewController: UIViewController {
 
@@ -74,4 +75,11 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
         cell.titleLabel.text = articles[indexPath.row].title
         return cell
     }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let articleUrl = URL(string: articles[indexPath.row].url) else { return }
+        let safariVC = SFSafariViewController(url: articleUrl)
+        present(safariVC, animated: true)
+    }
 }
+

--- a/CtaReactiveMaster/Sources/Repository/NewsArticleRepository.swift
+++ b/CtaReactiveMaster/Sources/Repository/NewsArticleRepository.swift
@@ -21,7 +21,7 @@ struct NewsArticleRepository: Repository {
     typealias Response = NewsDataModel
     
     func fetch() -> Observable<NewsDataModel> {
-        let request = NewsAPIRequest(endpoint: .topHeadline(country: .jp, category: .health))
+        let request = NewsAPIRequest(endpoint: .topHeadline(country: .jp, category: .business))
         return apiClient.request(request)
     }
 }

--- a/CtaReactiveMaster/UIImageView+Extension.swift
+++ b/CtaReactiveMaster/UIImageView+Extension.swift
@@ -1,0 +1,26 @@
+//
+//  UIImageView+Extension.swift
+//  CtaReactiveMaster
+//
+//  Created by 山根大生 on 2020/12/30.
+//
+
+import Nuke
+
+extension UIImageView {
+    func loadImage(from urlString: String?) {
+        guard let urlString = urlString, let url = URL(string: urlString) else {
+            self.image = UIImage(systemName: "photo")
+            return
+        }
+        let options = ImageLoadingOptions(
+            placeholder: UIImage(systemName: "photo"),
+            transition: .fadeIn(duration: 0.33),
+            failureImage: UIImage(systemName: "photo"),
+            failureImageTransition: .fadeIn(duration: 0.33),
+            contentModes: .init(success: .scaleAspectFill, failure: .scaleAspectFill, placeholder: .scaleAspectFill)
+        )
+        Nuke.loadImage(with: url, options: options, into: self)
+    }
+}
+


### PR DESCRIPTION
## 変更内容
- SafariでWebページを開けるようにした
- cellにauthor, description, imageの情報を追加

<img src="https://user-images.githubusercontent.com/50735539/103344024-c09b7a80-4ad0-11eb-9bd2-95a913317559.PNG" width="200px">

 
## 参考
- [cta_reactive_master_answer](https://github.com/CA21engineer/cta_reactive_master_answer)
- [Nuke Tutorial for iOS: Getting Started](https://www.raywenderlich.com/11070743-nuke-tutorial-for-ios-getting-started)

## その他 補足
- ipad Air(4th generation), iphoneXS, ipod touch(7th generation)でデバックしてみたところ、UIが崩れることなく正常に動作しました。

- `UIImage(systemName: "photo")`の動作の様子は以下の通りです。

<img src="https://user-images.githubusercontent.com/50735539/103357950-c35d9600-4af7-11eb-91e1-d51b453f0fc2.png" width="170px">
